### PR TITLE
[WIP] fun with docker & travis.

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/wire/alpine-builder
+WORKDIR /src/saml2-web-sso
+
+RUN apk add --no-cache git ncurses && \
+    mkdir -p /src && cd /src && \
+    git clone https://github.com/wireapp/saml2-web-sso && \
+    cd saml2-web-sso && \
+    mkdir -p /src/.stack-docker && ln -s /src/.stack-docker && \
+    stack update && \
+    echo -e "allow-different-user: true\n" >> /root/.stack/config.yaml && \
+    for RESOLVER in lts-10.3 lts-11.13 && do \
+        stack --resolver $RESOLVER --work-dir .stack-docker build --test --dependencies-only --no-run-tests && \
+    done

--- a/.travis/make.sh
+++ b/.travis/make.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+export IMAGE=quay.io/wire/alpine-saml2-web-sso
+
+docker build .
+
+export GIT_HASH=`docker run -it --rm $IMAGE:latest /bin/sh -c "cd /src/saml2-web-sso && git rev-parse --short HEAD"`
+GIT_HASH=${GIT_HASH:0:7}  # Remove trailing '\r' character from the end.
+docker tag $IMAGE:latest $IMAGE:$GIT_HASH
+
+docker login quay.io
+docker push $IMAGE:$GIT_HASH

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export IMAGE=quay.io/wire/alpine-saml2-web-sso
+docker pull $IMAGE
+
+export VOLUMES="-v `pwd`:/src/saml2-web-sso"
+[ "$1" = "--connect" ] && export CONNECT_TO_RUNNING_CONTAINER=1
+[ "$1" != "" ] && export RUN_CMD="$1"
+
+if [ "$CONNECT_TO_RUNNING_CONTAINER" = "1" ]; then
+    docker exec -it `docker ps -q --filter="ancestor=$IMAGE"` /bin/bash
+else
+    docker run -it --rm $VOLUMES $IMAGE /bin/bash -c "$RUN_CMD"
+fi

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+ln -s /src/.stack-docker
+for RESOLVER in lts-10.3 lts-11.13; do
+    stack --resolver $RESOLVER --work-dir .stack-docker build --test --dependencies-only --no-run-tests


### PR DESCRIPTION
we probably don't want to build a new docker image here, but use alpine-builder from wire-server.  the plan is:

1. wait for https://github.com/wireapp/wire-server/pull/373
2. limit saml2-web-sso so the resolver supported by alpine-builder, and drop 10.3
3. write a script that uses both a current working copy of saml2-web-sso from outside the image and the .stack-docker dir from inside the image to build & test saml2-web-sso.  (details to be figured out; see https://github.com/liqd/aula/, https://github.com/liqd/aula-docker/ for one way to do it.)