### PR TITLE
Add cabal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@
 /.stack-work
 *.tix
 *.pem
-/saml2-web-sso.cabal
 /server.yaml
 TAGS

--- a/saml2-web-sso.cabal
+++ b/saml2-web-sso.cabal
@@ -1,0 +1,265 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.32.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 6d57eb8ca10b1a078d0a5d45f7a96965bc9e4bb29dcd8c21387ea66afb01d21e
+
+name:           saml2-web-sso
+version:        0.18
+synopsis:       Library and example web app for the SAML Web-based SSO profile.
+description:    See README.md
+category:       System
+author:         Wire Swiss GmbH
+maintainer:     Wire Swiss GmbH <backend@wire.com>
+copyright:      (c) 2017 Wire Swiss GmbH
+license:        AGPL-3
+license-file:   LICENSE
+build-type:     Simple
+
+library
+  exposed-modules:
+      SAML2.Util
+      SAML2.WebSSO
+      SAML2.WebSSO.API
+      SAML2.WebSSO.API.Example
+      SAML2.WebSSO.Config
+      SAML2.WebSSO.Cookie
+      SAML2.WebSSO.Error
+      SAML2.WebSSO.Orphans
+      SAML2.WebSSO.Servant
+      SAML2.WebSSO.Servant.CPP
+      SAML2.WebSSO.SP
+      SAML2.WebSSO.Test.Arbitrary
+      SAML2.WebSSO.Test.Credentials
+      SAML2.WebSSO.Test.Lenses
+      SAML2.WebSSO.Test.MockResponse
+      SAML2.WebSSO.Types
+      SAML2.WebSSO.Types.TH
+      SAML2.WebSSO.XML
+      Text.XML.DSig
+      Text.XML.Util
+  other-modules:
+      Paths_saml2_web_sso
+  hs-source-dirs:
+      src
+  default-extensions: NoOverloadedStrings ConstraintKinds DataKinds DefaultSignatures DeriveGeneric FlexibleContexts FlexibleInstances GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses NoMonomorphismRestriction PolyKinds QuasiQuotes RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances ViewPatterns
+  ghc-options: -j -O2 -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wtabs -Werror
+  build-depends:
+      QuickCheck >=2.13.2
+    , aeson >=1.4.5.0
+    , asn1-encoding >=0.9.6
+    , asn1-parse >=0.9.5
+    , asn1-types >=0.3.3
+    , base >=4.12.0.0
+    , base64-bytestring >=1.0.0.2
+    , binary >=0.8.6.0
+    , bytestring >=0.10.8.2
+    , containers >=0.6.0.1
+    , cookie >=0.4.4
+    , cryptonite >=0.25
+    , data-default >=0.7.1.1
+    , dns >=4.0.0
+    , email-validate >=2.3.2.12
+    , errors >=2.3.0
+    , exceptions >=0.10.3
+    , extra >=1.6.18
+    , filepath >=1.4.2.1
+    , foundation >=0.0.25
+    , ghc-prim >=0.5.3
+    , hedgehog >=1.0.1
+    , hedgehog-quickcheck >=0.1.1
+    , hourglass >=0.2.12
+    , hsaml2 >=0.1
+    , http-media >=0.8.0.0
+    , http-types >=0.12.3
+    , hxt >=9.3.1.18
+    , lens >=4.17.1
+    , lens-datetime >=0.3
+    , memory >=0.14.18
+    , mtl >=2.2.2
+    , network-uri >=2.6.1.0
+    , pretty-show >=1.9.5
+    , quickcheck-instances >=0.3.22
+    , random >=1.1
+    , servant >=0.16.2
+    , servant-multipart >=0.11.4
+    , servant-server >=0.16.2
+    , silently >=1.2.5.1
+    , string-conversions >=0.4.0.1
+    , text >=1.2.3.1
+    , time >=1.8.0.2
+    , transformers >=0.5.6.2
+    , uniplate >=1.6.12
+    , uri-bytestring >=0.3.2.2
+    , uuid >=1.3.13
+    , wai >=3.2.2.1
+    , warp >=3.2.28
+    , x509 >=1.7.5
+    , xml-conduit >=1.8.0.1
+    , xml-conduit-writer >=0.1.1.2
+    , xml-hamlet >=0.5.0.1
+    , xml-types >=0.3.6
+    , yaml >=0.8.25.1
+  default-language: Haskell2010
+
+executable toy-sp
+  main-is: Main.hs
+  other-modules:
+      Paths_saml2_web_sso
+  hs-source-dirs:
+      toy-sp
+  default-extensions: NoOverloadedStrings ConstraintKinds DataKinds DefaultSignatures DeriveGeneric FlexibleContexts FlexibleInstances GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses NoMonomorphismRestriction PolyKinds QuasiQuotes RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances ViewPatterns
+  ghc-options: -j -O2 -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wtabs -Werror
+  build-depends:
+      QuickCheck >=2.13.2
+    , aeson >=1.4.5.0
+    , asn1-encoding >=0.9.6
+    , asn1-parse >=0.9.5
+    , asn1-types >=0.3.3
+    , base >=4.12.0.0
+    , base64-bytestring >=1.0.0.2
+    , binary >=0.8.6.0
+    , bytestring >=0.10.8.2
+    , containers >=0.6.0.1
+    , cookie >=0.4.4
+    , cryptonite >=0.25
+    , data-default >=0.7.1.1
+    , dns >=4.0.0
+    , email-validate >=2.3.2.12
+    , errors >=2.3.0
+    , exceptions >=0.10.3
+    , extra >=1.6.18
+    , filepath >=1.4.2.1
+    , foundation >=0.0.25
+    , ghc-prim >=0.5.3
+    , hedgehog >=1.0.1
+    , hedgehog-quickcheck >=0.1.1
+    , hourglass >=0.2.12
+    , hsaml2 >=0.1
+    , http-media >=0.8.0.0
+    , http-types >=0.12.3
+    , hxt >=9.3.1.18
+    , lens >=4.17.1
+    , lens-datetime >=0.3
+    , memory >=0.14.18
+    , mtl >=2.2.2
+    , network-uri >=2.6.1.0
+    , pretty-show >=1.9.5
+    , quickcheck-instances >=0.3.22
+    , random >=1.1
+    , saml2-web-sso
+    , servant >=0.16.2
+    , servant-multipart >=0.11.4
+    , servant-server >=0.16.2
+    , silently >=1.2.5.1
+    , string-conversions >=0.4.0.1
+    , text >=1.2.3.1
+    , time >=1.8.0.2
+    , transformers >=0.5.6.2
+    , uniplate >=1.6.12
+    , uri-bytestring >=0.3.2.2
+    , uuid >=1.3.13
+    , wai >=3.2.2.1
+    , warp >=3.2.28
+    , x509 >=1.7.5
+    , xml-conduit >=1.8.0.1
+    , xml-conduit-writer >=0.1.1.2
+    , xml-hamlet >=0.5.0.1
+    , xml-types >=0.3.6
+    , yaml >=0.8.25.1
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Samples
+      Test.SAML2.UtilSpec
+      Test.SAML2.WebSSO.API.ExampleSpec
+      Test.SAML2.WebSSO.APISpec
+      Test.SAML2.WebSSO.ConfigSpec
+      Test.SAML2.WebSSO.RoundtripSpec
+      Test.SAML2.WebSSO.SPSpec
+      Test.SAML2.WebSSO.XML.ExamplesSpec
+      Test.SAML2.WebSSO.XML.MetaSpec
+      Test.SAML2.WebSSO.XMLSpec
+      Test.Text.XML.DSigSpec
+      Test.Text.XML.UtilSpec
+      Util
+      Util.Misc
+      Util.TestSP
+      Util.Types
+      Util.VendorCompatibility
+      Paths_saml2_web_sso
+  hs-source-dirs:
+      test
+  default-extensions: NoOverloadedStrings ConstraintKinds DataKinds DefaultSignatures DeriveGeneric FlexibleContexts FlexibleInstances GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses NoMonomorphismRestriction PolyKinds QuasiQuotes RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances ViewPatterns
+  ghc-options: -j -O2 -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wtabs -Werror -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      QuickCheck >=2.13.2
+    , aeson >=1.4.5.0
+    , asn1-encoding >=0.9.6
+    , asn1-parse >=0.9.5
+    , asn1-types >=0.3.3
+    , base >=4.12.0.0
+    , base64-bytestring >=1.0.0.2
+    , binary >=0.8.6.0
+    , bytestring >=0.10.8.2
+    , containers >=0.6.0.1
+    , cookie >=0.4.4
+    , cryptonite >=0.25
+    , data-default >=0.7.1.1
+    , dns >=4.0.0
+    , email-validate >=2.3.2.12
+    , errors >=2.3.0
+    , exceptions >=0.10.3
+    , extra >=1.6.18
+    , filepath >=1.4.2.1
+    , foundation >=0.0.25
+    , ghc-prim >=0.5.3
+    , hedgehog
+    , hedgehog-quickcheck >=0.1.1
+    , hourglass >=0.2.12
+    , hsaml2 >=0.1
+    , hspec
+    , hspec-core
+    , hspec-discover
+    , hspec-wai
+    , http-media >=0.8.0.0
+    , http-types >=0.12.3
+    , hxt >=9.3.1.18
+    , lens >=4.17.1
+    , lens-datetime >=0.3
+    , memory >=0.14.18
+    , mtl >=2.2.2
+    , network-uri >=2.6.1.0
+    , pretty-show
+    , process
+    , quickcheck-instances >=0.3.22
+    , random >=1.1
+    , saml2-web-sso
+    , servant >=0.16.2
+    , servant-multipart >=0.11.4
+    , servant-server >=0.16.2
+    , shelly
+    , silently >=1.2.5.1
+    , string-conversions >=0.4.0.1
+    , temporary
+    , text >=1.2.3.1
+    , time >=1.8.0.2
+    , transformers >=0.5.6.2
+    , uniplate >=1.6.12
+    , uri-bytestring >=0.3.2.2
+    , uuid >=1.3.13
+    , wai >=3.2.2.1
+    , wai-extra
+    , warp >=3.2.28
+    , x509 >=1.7.5
+    , xml-conduit >=1.8.0.1
+    , xml-conduit-writer >=0.1.1.2
+    , xml-hamlet >=0.5.0.1
+    , xml-types >=0.3.6
+    , yaml >=0.8.25.1
+  default-language: Haskell2010


### PR DESCRIPTION
Not having it here is problematic, as packages depending on it can't pin
the repository as the hash of the repository depends on the version of
hpack used which can vary from system to system.

Stack is actually changing this behaviour soon:
https://tech.fpcomplete.com/blog/storing-generated-cabal-files

We hit this bug here:
https://github.com/wireapp/wire-server/pull/1027#issuecomment-603415273
where now CI isn't reproducible because the cabal file generated on my
machine doesn't match the cabal file generated on CI