### PR TITLE
Improve errors for XML parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 *.pem
 /server.yaml
 TAGS
+**/do-not-commit

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ dependencies:
   - base64-bytestring >=1.0.0.2
   - binary >=0.8.6.0
   - bytestring >=0.10.8.2
+  - case-insensitive >= 1.2.1.0
   - containers >=0.6.0.1
   - cookie >=0.4.4
   - cryptonite >=0.25

--- a/saml2-web-sso.cabal
+++ b/saml2-web-sso.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c11d0db3c29b8e7b9e2f65bd886ece63bf344f6f4dd9d4510c0d6e166b1ef825
+-- hash: 52bebd38426c08f1d78a6ca88d5f8511740efb741b64c7e0ec1b44eb711be801
 
 name:           saml2-web-sso
 version:        0.18
@@ -60,6 +60,7 @@ library
     , base64-bytestring >=1.0.0.2
     , binary >=0.8.6.0
     , bytestring >=0.10.8.2
+    , case-insensitive >=1.2.1.0
     , containers >=0.6.0.1
     , cookie >=0.4.4
     , cryptonite >=0.25
@@ -132,6 +133,7 @@ executable toy-sp
     , base64-bytestring >=1.0.0.2
     , binary >=0.8.6.0
     , bytestring >=0.10.8.2
+    , case-insensitive >=1.2.1.0
     , containers >=0.6.0.1
     , cookie >=0.4.4
     , cryptonite >=0.25
@@ -218,6 +220,7 @@ test-suite spec
     , base64-bytestring >=1.0.0.2
     , binary >=0.8.6.0
     , bytestring >=0.10.8.2
+    , case-insensitive >=1.2.1.0
     , containers >=0.6.0.1
     , cookie >=0.4.4
     , cryptonite >=0.25

--- a/src/SAML2/WebSSO/XML.hs
+++ b/src/SAML2/WebSSO/XML.hs
@@ -887,13 +887,14 @@ parseIdPMetadataHead el@(Element tag attrs _) = do
     Issuer <$> parseURI' issueruri
   _edRequestURI :: URI <- do
     target :: ST <-
-      [fromNode (NodeElement el)]
-        & ( findSome "IDPSSODescriptor element" (descendant >=> element "{urn:oasis:names:tc:SAML:2.0:metadata}IDPSSODescriptor")
-              >=> findSome "SingleSignOnService element" (child >=> element "{urn:oasis:names:tc:SAML:2.0:metadata}SingleSignOnService")
-              >=> findSome "\"Binding\" attribute with value \"HTTP-POST\"" (attributeIsCI "Binding" "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")
-              >=> getSingleton "\"Binding\" attribute with value \"HTTP-POST\""
-              >=> attribute "Location" >>> getSingleton "\"Location\""
-          )
+      let bindingDescr = "\"Binding\" attribute with value \"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\""
+       in [fromNode (NodeElement el)]
+            & ( findSome "IDPSSODescriptor element" (descendant >=> element "{urn:oasis:names:tc:SAML:2.0:metadata}IDPSSODescriptor")
+                  >=> findSome "SingleSignOnService element" (child >=> element "{urn:oasis:names:tc:SAML:2.0:metadata}SingleSignOnService")
+                  >=> findSome bindingDescr (attributeIsCI "Binding" "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")
+                  >=> getSingleton bindingDescr
+                  >=> attribute "Location" >>> getSingleton "\"Location\""
+              )
     case parseURI' target of
       Right uri -> pure uri
       Left msg -> throwError $ "bad request uri: " <> msg

--- a/src/SAML2/WebSSO/XML.hs
+++ b/src/SAML2/WebSSO/XML.hs
@@ -867,7 +867,17 @@ getSingleton _ [x] = pure x
 getSingleton descr [] = throwError ("Couldnt find any matches for: " <> descr)
 getSingleton descr _ = throwError ("Expected only one but found multiple matches for: " <> descr)
 
--- | case insensitive version fo 'attributeIs'
+-- | Case insensitive version fo 'attributeIs'.  NB: this is generally violating the standard
+-- (see below), but in many cases there is clearly no harm in doing so (it's hard to base an
+-- attack on being able to say `HTTP-Post` instead of `HTTP-POST`).
+--
+-- Details:
+-- * According to https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf,
+--   Section 3.5.1, the binding should be "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+--   but what you sent is "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post".
+-- * According to https://tools.ietf.org/html/rfc8141, page 17, URNs are case sensitive in the
+--   position of "HTTP-Post".  All SAML IdPs that wire supports, including microsoft azure,
+--   okta, and centrify are following this line of reasoning.
 attributeIsCI :: Name -> CI ST -> (Cursor -> [Cursor])
 attributeIsCI name attValue = checkNode $ \case
   NodeElement (Element _ as _) ->

--- a/src/SAML2/WebSSO/XML.hs
+++ b/src/SAML2/WebSSO/XML.hs
@@ -876,7 +876,7 @@ parseIdPMetadataHead el@(Element tag attrs _) = do
     target :: ST <-
       [fromNode (NodeElement el)]
         & ( findSome "IDPSSODescriptor element" (descendant >=> element "{urn:oasis:names:tc:SAML:2.0:metadata}IDPSSODescriptor")
-              >=> findSome "SingleSignOnService" (child >=> element "{urn:oasis:names:tc:SAML:2.0:metadata}SingleSignOnService")
+              >=> findSome "SingleSignOnService element" (child >=> element "{urn:oasis:names:tc:SAML:2.0:metadata}SingleSignOnService")
               >=> findSome "\"Binding\" attribute with value \"HTTP-POST\"" (attributeIs "Binding" "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")
               >=> getSingleton "\"Binding\" attribute with value \"HTTP-POST\""
               >=> attribute "Location" >>> getSingleton "\"Location\""

--- a/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/test/Test/SAML2/WebSSO/APISpec.hs
@@ -247,7 +247,7 @@ spec = describe "API" $ do
     let parseSample :: FilePath -> IO (Either String IdPMetadata)
         parseSample samplePath = decode <$> readSampleIO samplePath
 
-    it "fails when HTTP-POST with helpful error message" $ do
+    it "fails with helpful error message if HTTP-POST is missing" $ do
       res <- parseSample "post-missing.xml"
       res `shouldBe` Left "Couldnt find any matches for: \"Binding\" attribute with value \"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\""
 

--- a/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/test/Test/SAML2/WebSSO/APISpec.hs
@@ -208,6 +208,7 @@ spec = describe "API" $ do
       it "responds with 303" . runtest $ \ctx -> do
         postTestAuthnResp ctx False False
           `shouldRespondWith` 303 {matchBody = bodyContains "<body><p>SSO successful, redirecting to"}
+
   describe "mkAuthnResponse (this is testing the test helpers)" $ do
     it "Produces output that decodes into 'AuthnResponse'" $ do
       ctx <- mkTestCtxWithIdP
@@ -241,6 +242,15 @@ spec = describe "API" $ do
       check True isRight
     it "Produces output that is rejected by 'simpleVerifyAuthnResponse' if the signature is wrong" $ do
       check False isLeft
+
+  describe "IdPMetadata parsing" $ do
+    let parseSample :: FilePath -> IO (Either String IdPMetadata)
+        parseSample samplePath = decode <$> readSampleIO samplePath
+
+    it "fails when HTTP-POST with helpful error message" $ do
+      res <- parseSample "post-missing.xml"
+      res `shouldBe` Left "Couldnt find any matches for: \"Binding\" attribute with value \"HTTP-POST\""
+
   describe "vendor compatibility tests" $ do
     vendorCompatibility "okta.com" [uri|https://staging-nginz-https.zinfra.io/sso/finalize-login|]
     -- https://developer.okta.com/signup/

--- a/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/test/Test/SAML2/WebSSO/APISpec.hs
@@ -251,6 +251,10 @@ spec = describe "API" $ do
       res <- parseSample "post-missing.xml"
       res `shouldBe` Left "Couldnt find any matches for: \"Binding\" attribute with value \"HTTP-POST\""
 
+    it "succeeds with HTTP-Post (not all caps)" $ do
+      res <- parseSample "authnresponse-case-insensitive.xml"
+      res `shouldSatisfy` isRight
+
   describe "vendor compatibility tests" $ do
     vendorCompatibility "okta.com" [uri|https://staging-nginz-https.zinfra.io/sso/finalize-login|]
     -- https://developer.okta.com/signup/

--- a/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/test/Test/SAML2/WebSSO/APISpec.hs
@@ -249,7 +249,7 @@ spec = describe "API" $ do
 
     it "fails when HTTP-POST with helpful error message" $ do
       res <- parseSample "post-missing.xml"
-      res `shouldBe` Left "Couldnt find any matches for: \"Binding\" attribute with value \"HTTP-POST\""
+      res `shouldBe` Left "Couldnt find any matches for: \"Binding\" attribute with value \"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\""
 
     it "succeeds with HTTP-Post (not all caps)" $ do
       res <- parseSample "authnresponse-case-insensitive.xml"

--- a/test/samples/authnresponse-case-insensitive.xml
+++ b/test/samples/authnresponse-case-insensitive.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+	                             xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+	                             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+	                             entityID="https://foo.bar">
+
+	  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		    <md:KeyDescriptor use="signing">
+			      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				        <ds:X509Data>
+					          <ds:X509Certificate>
+MIIDBTCCAe2gAwIBAgIQev76BWqjWZxChmKkGqoAfDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE4MDIxODAwMDAwMFoXDTIwMDIxOTAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMgmGiRfLh6Fdi99XI2VA3XKHStWNRLEy5Aw/gxFxchnh2kPdk/bejFOs2swcx7yUWqxujjCNRsLBcWfaKUlTnrkY7i9x9noZlMrijgJy/Lk+HH5HX24PQCDf+twjnHHxZ9G6/8VLM2e5ZBeZm+t7M3vhuumEHG3UwloLF6cUeuPdW+exnOB1U1fHBIFOG8ns4SSIoq6zw5rdt0CSI6+l7b1DEjVvPLtJF+zyjlJ1Qp7NgBvAwdiPiRMU4l8IRVbuSVKoKYJoyJ4L3eXsjczoBSTJ6VjV2mygz96DC70MY3avccFrk7tCEC6ZlMRBfY1XPLyldT7tsR3EuzjecSa1M8CAwEAAaMhMB8wHQYDVR0OBBYEFIks1srixjpSLXeiR8zES5cTY6fBMA0GCSqGSIb3DQEBCwUAA4IBAQCKthfK4C31DMuDyQZVS3F7+4Evld3hjiwqu2uGDK+qFZas/D/eDunxsFpiwqC01RIMFFN8yvmMjHphLHiBHWxcBTS+tm7AhmAvWMdxO5lzJLS+UWAyPF5ICROe8Mu9iNJiO5JlCo0Wpui9RbB1C81Xhax1gWHK245ESL6k7YWvyMYWrGqr1NuQcNS0B/AIT1Nsj1WY7efMJQOmnMHkPUTWryVZlthijYyd7P2Gz6rY5a81DAFqhDNJl2pGIAE6HWtSzeUEh3jCsHEkoglKfm4VrGJEuXcALmfCMbdfTvtu4rlsaP2hQad+MG/KJFlenoTK34EMHeBPDCpqNDz8UVNk
+                    </ds:X509Certificate>
+				        </ds:X509Data>
+			      </ds:KeyInfo>
+		    </md:KeyDescriptor>
+
+		    <md:SingleSignOnService
+				    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"
+				             Location="https://foo.bar/appsso/login"/>
+
+	  </md:IDPSSODescriptor>
+</md:EntityDescriptor>

--- a/test/samples/post-missing.xml
+++ b/test/samples/post-missing.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+	xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+	entityID="https://foo.bar">
+
+	<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<md:KeyDescriptor use="signing">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>
+MIIDBTCCAe2gAwIBAgIQev76BWqjWZxChmKkGqoAfDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE4MDIxODAwMDAwMFoXDTIwMDIxOTAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMgmGiRfLh6Fdi99XI2VA3XKHStWNRLEy5Aw/gxFxchnh2kPdk/bejFOs2swcx7yUWqxujjCNRsLBcWfaKUlTnrkY7i9x9noZlMrijgJy/Lk+HH5HX24PQCDf+twjnHHxZ9G6/8VLM2e5ZBeZm+t7M3vhuumEHG3UwloLF6cUeuPdW+exnOB1U1fHBIFOG8ns4SSIoq6zw5rdt0CSI6+l7b1DEjVvPLtJF+zyjlJ1Qp7NgBvAwdiPiRMU4l8IRVbuSVKoKYJoyJ4L3eXsjczoBSTJ6VjV2mygz96DC70MY3avccFrk7tCEC6ZlMRBfY1XPLyldT7tsR3EuzjecSa1M8CAwEAAaMhMB8wHQYDVR0OBBYEFIks1srixjpSLXeiR8zES5cTY6fBMA0GCSqGSIb3DQEBCwUAA4IBAQCKthfK4C31DMuDyQZVS3F7+4Evld3hjiwqu2uGDK+qFZas/D/eDunxsFpiwqC01RIMFFN8yvmMjHphLHiBHWxcBTS+tm7AhmAvWMdxO5lzJLS+UWAyPF5ICROe8Mu9iNJiO5JlCo0Wpui9RbB1C81Xhax1gWHK245ESL6k7YWvyMYWrGqr1NuQcNS0B/AIT1Nsj1WY7efMJQOmnMHkPUTWryVZlthijYyd7P2Gz6rY5a81DAFqhDNJl2pGIAE6HWtSzeUEh3jCsHEkoglKfm4VrGJEuXcALmfCMbdfTvtu4rlsaP2hQad+MG/KJFlenoTK34EMHeBPDCpqNDz8UVNk
+					</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+		</md:KeyDescriptor>
+
+		<md:SingleSignOnService
+				Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+				Location="https://foo.bar/appsso/login"/>
+
+		<md:SingleLogoutService
+		      Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+          Location="https://foo.bar/appsso/logout" />
+
+	 </md:IDPSSODescriptor>
+</md:EntityDescriptor>


### PR DESCRIPTION
This PR:
- improves `IdPMetadata` parsing errors
- relaxes the parses so that matches SingleSignOnService "Binding" attribute in a case-insensitive way

The certificates in the test cases are copied from `microsoft-authnresponse-2.xml`