### PR TITLE
Bump ormolu version.

### DIFF
--- a/src/SAML2/WebSSO/SP.hs
+++ b/src/SAML2/WebSSO/SP.hs
@@ -6,9 +6,9 @@ import Control.Lens hiding (Level)
 import Control.Monad.Except
 import Control.Monad.Extra (ifM)
 import Control.Monad.Reader
-import Data.Kind (Type)
 import Control.Monad.Writer
 import Data.Foldable (toList)
+import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe
 import qualified Data.Semigroup

--- a/src/Text/XML/DSig.hs
+++ b/src/Text/XML/DSig.hs
@@ -306,9 +306,9 @@ signRootAt sigPos (SignPrivCreds hashAlg (SignPrivKeyRSA keypair)) doc =
     -- (note that there are two rounds of SHA256 application, hence two mentions of the has alg here)
 
     signedInfoSBS :: SBS <-
-      either (throwError . show) (pure . cs) . unsafePerformIO . try @SomeException
-        $ HS.applyCanonicalization (HS.signedInfoCanonicalizationMethod signedInfo) Nothing
-        $ HS.samlToDoc signedInfo
+      either (throwError . show) (pure . cs) . unsafePerformIO . try @SomeException $
+        HS.applyCanonicalization (HS.signedInfoCanonicalizationMethod signedInfo) Nothing $
+          HS.samlToDoc signedInfo
     sigval :: SBS <-
       either (throwError . show @RSA.Error) pure
         =<< RSA.signSafer

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.10
+resolver: lts-16.14
 
 packages:
 - .
@@ -11,8 +11,8 @@ extra-deps:
 - invertible-hxt-0.1  # for hsaml2
 - servant-multipart-0.11.5 # Dropped from stackage
 
-- ormolu-0.1.2.0
-- ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751  # for ormolu-0.0.5.0
+- ormolu-0.1.4.1
+- ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751  # for ormolu
 nix:
   packages:
   - zlib

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -56,7 +56,7 @@ packages:
     hackage: ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751
 snapshots:
 - completed:
-    size: 532383
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/10.yaml
-    sha256: 469d781ab6d2a4eceed6b31b6e4ec842dcd3cd1d11577972e86902603dce24df
-  original: lts-16.10
+    size: 532382
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/14.yaml
+    sha256: 1ef27e36f38824abafc43224ca612211b3828fa9ffd31ba0fc2867ae2e19ba90
+  original: lts-16.14


### PR DESCRIPTION
No change in formatting of the existing code, but some [nice bug fixes](https://hackage.haskell.org/package/ormolu-0.1.4.1/changelog).  (Ormolu formatting seems to stabilize.  Good.)