### PR TITLE
Case insensitive email

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -87,6 +87,7 @@ dependencies:
   - uuid >=1.3.13
   - wai >=3.2.2.1
   - warp >=3.2.28
+  - word8 >=0.1.3
   - x509 >=1.7.5
   - xml-conduit >=1.8.0.1
   - xml-conduit-writer >=0.1.1.2

--- a/saml2-web-sso.cabal
+++ b/saml2-web-sso.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 52bebd38426c08f1d78a6ca88d5f8511740efb741b64c7e0ec1b44eb711be801
+-- hash: 5291fba66e21d262c827b52ff6a763e8e6dd4642b7edee7dcfa736d6a5ce7c46
 
 name:           saml2-web-sso
 version:        0.18
@@ -40,6 +40,7 @@ library
       SAML2.WebSSO.Test.Util.Types
       SAML2.WebSSO.Test.Util.VendorCompatibility
       SAML2.WebSSO.Types
+      SAML2.WebSSO.Types.Email
       SAML2.WebSSO.Types.TH
       SAML2.WebSSO.XML
       Text.XML.DSig

--- a/saml2-web-sso.cabal
+++ b/saml2-web-sso.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5291fba66e21d262c827b52ff6a763e8e6dd4642b7edee7dcfa736d6a5ce7c46
+-- hash: 75e35512ef3af4dae35ff34a07647dd316348c29640c2c3d64479d061a9c31cd
 
 name:           saml2-web-sso
 version:        0.18
@@ -109,6 +109,7 @@ library
     , wai >=3.2.2.1
     , wai-extra >=3.0.28
     , warp >=3.2.28
+    , word8 >=0.1.3
     , x509 >=1.7.5
     , xml-conduit >=1.8.0.1
     , xml-conduit-writer >=0.1.1.2
@@ -184,6 +185,7 @@ executable toy-sp
     , wai >=3.2.2.1
     , wai-extra >=3.0.28
     , warp >=3.2.28
+    , word8 >=0.1.3
     , x509 >=1.7.5
     , xml-conduit >=1.8.0.1
     , xml-conduit-writer >=0.1.1.2
@@ -274,6 +276,7 @@ test-suite spec
     , wai >=3.2.2.1
     , wai-extra >=3.0.28
     , warp >=3.2.28
+    , word8 >=0.1.3
     , x509 >=1.7.5
     , xml-conduit >=1.8.0.1
     , xml-conduit-writer >=0.1.1.2

--- a/src/SAML2/WebSSO/API.hs
+++ b/src/SAML2/WebSSO/API.hs
@@ -317,16 +317,25 @@ type Cky = Cky.SimpleSetCookie CookieName
 
 type CookieName = "saml2-web-sso"
 
+data SubjectFoldCase
+  = SubjectFoldCase
+  | SubjectDontFoldCase
+
 simpleOnSuccess ::
   SP m =>
+  SubjectFoldCase ->
   OnSuccessRedirect m
-simpleOnSuccess uid = do
+simpleOnSuccess foldCase uid = do
   cky <- Cky.toggleCookie "/" $ Just (userRefToST uid, defReqTTL)
   appuri <- (^. cfgSPAppURI) <$> getConfig
   pure (cky, appuri)
   where
     userRefToST :: UserRef -> ST
-    userRefToST (UserRef (Issuer tenant) subject) = "{" <> renderURI tenant <> "}" <> CI.foldedCase (nameIDToST subject)
+    userRefToST (UserRef (Issuer tenant) subject) = "{" <> renderURI tenant <> "}" <> renderSubject subject
+    renderSubject subject =
+      case foldCase of
+        SubjectFoldCase -> CI.foldedCase (nameIDToST subject)
+        SubjectDontFoldCase -> CI.original (nameIDToST subject)
 
 -- | We support two cases: redirect with a cookie, and a generic response with arbitrary status,
 -- headers, and body.  The latter case fits the 'ServerError' type well, but we give it a more

--- a/src/SAML2/WebSSO/API.hs
+++ b/src/SAML2/WebSSO/API.hs
@@ -24,6 +24,7 @@ import Control.Lens hiding (element)
 import Control.Monad.Except hiding (ap)
 import qualified Data.ByteString.Base64.Lazy as EL (decodeLenient, encode)
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.CaseInsensitive as CI
 import Data.Either (isRight)
 import Data.EitherR
 import Data.List.NonEmpty (NonEmpty)
@@ -323,6 +324,9 @@ simpleOnSuccess uid = do
   cky <- Cky.toggleCookie "/" $ Just (userRefToST uid, defReqTTL)
   appuri <- (^. cfgSPAppURI) <$> getConfig
   pure (cky, appuri)
+  where
+    userRefToST :: UserRef -> ST
+    userRefToST (UserRef (Issuer tenant) subject) = "{" <> renderURI tenant <> "}" <> CI.foldedCase (nameIDToST subject)
 
 -- | We support two cases: redirect with a cookie, and a generic response with arbitrary status,
 -- headers, and body.  The latter case fits the 'ServerError' type well, but we give it a more

--- a/src/SAML2/WebSSO/API/Example.hs
+++ b/src/SAML2/WebSSO/API/Example.hs
@@ -180,7 +180,7 @@ spapi :: (MonadApp m) => ServerT SPAPI m
 spapi = loginStatus :<|> localLogout :<|> singleLogout
 
 appapi :: (MonadApp m) => ServerT APPAPI m
-appapi = spapi :<|> api "toy-sp" (HandleVerdictRedirect simpleOnSuccess)
+appapi = spapi :<|> api "toy-sp" (HandleVerdictRedirect (simpleOnSuccess SubjectFoldCase))
 
 loginStatus :: (GetAllIdPs err m, SP m) => Maybe Cky -> m LoginStatus
 loginStatus cookie = do

--- a/src/SAML2/WebSSO/Test/Arbitrary.hs
+++ b/src/SAML2/WebSSO/Test/Arbitrary.hs
@@ -21,11 +21,11 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Gen.QuickCheck as THQ
 import qualified Hedgehog.Range as Range
 import SAML2.WebSSO
+import qualified SAML2.WebSSO.Types.Email as Email
 import Servant.Multipart
 import Test.QuickCheck (Arbitrary (arbitrary, shrink))
 import qualified Test.QuickCheck.Hedgehog as TQH
 import Test.QuickCheck.Instances ()
-import qualified Text.Email.Validate as Email
 import Text.XML
 import qualified Text.XML.DSig as DSig
 import URI.ByteString
@@ -214,10 +214,10 @@ genEmailURI = do
   loc <- genNiceWord
   pure . unsafeParseURI $ "email:" <> loc <> "@example.com"
 
-genEmail :: HasCallStack => Gen Email
+genEmail :: HasCallStack => Gen Email.Email
 genEmail = do
   loc <- genNiceWord
-  maybe (error "genEmail") (pure . Email) . Email.emailAddress . cs $ loc <> "@example.com"
+  either (error . ("genEmail: " <>)) pure . Email.validate $ loc <> "@example.com"
 
 genAuthnRequest :: Gen AuthnRequest
 genAuthnRequest =

--- a/src/SAML2/WebSSO/Test/Arbitrary.hs
+++ b/src/SAML2/WebSSO/Test/Arbitrary.hs
@@ -4,6 +4,7 @@
 module SAML2.WebSSO.Test.Arbitrary where
 
 import Control.Lens
+import qualified Data.CaseInsensitive as CI
 import Data.List.NonEmpty as NL
 import qualified Data.Map as Map
 import Data.Proxy
@@ -214,7 +215,7 @@ genEmailURI = do
   loc <- genNiceWord
   pure . unsafeParseURI $ "email:" <> loc <> "@example.com"
 
-genEmail :: HasCallStack => Gen Email.Email
+genEmail :: HasCallStack => Gen (CI.CI Email.Email)
 genEmail = do
   loc <- genNiceWord
   either (error . ("genEmail: " <>)) pure . Email.validate $ loc <> "@example.com"

--- a/src/SAML2/WebSSO/Test/Util/VendorCompatibility.hs
+++ b/src/SAML2/WebSSO/Test/Util/VendorCompatibility.hs
@@ -31,7 +31,7 @@ testAuthRespApp :: HasCallStack => URI.URI -> SpecWith (CtxV, Application) -> Sp
 testAuthRespApp ssoURI =
   withapp
     (Proxy @("sso" :> APIAuthResp'))
-    (authresp' spissuer respuri (HandleVerdictRedirect simpleOnSuccess))
+    (authresp' spissuer respuri (HandleVerdictRedirect (simpleOnSuccess SubjectFoldCase)))
     mkTestCtxSimple
   where
     spissuer = Issuer <$> respuri

--- a/src/SAML2/WebSSO/Types.hs
+++ b/src/SAML2/WebSSO/Types.hs
@@ -159,12 +159,8 @@ where
 
 import Control.Lens
 import Control.Monad.Except
-import Data.Aeson as Aeson
+import Data.Aeson
 import Data.Aeson.TH
--- FUTUREWORK: should saml2-web-sso also use the URI from http-types?  we already
--- depend on that via xml-conduit anyway.  (is it a problem though that it is
--- string-based?  is it less of a problem because we need it anyway?)
-
 import Data.Bifunctor (first)
 import qualified Data.List as L
 import Data.List.NonEmpty
@@ -817,86 +813,6 @@ newtype EitherFail a = EitherFail {unwrapEitherFail :: Either String a}
 
 instance MonadFail EitherFail where
   fail s = EitherFail (Left s)
-
-instance FromJSON Status
-
-instance ToJSON Status
-
-instance FromJSON DeniedReason
-
-instance ToJSON DeniedReason
-
-instance FromJSON AuthnResponse
-
-instance ToJSON AuthnResponse
-
-instance FromJSON Assertion
-
-instance ToJSON Assertion
-
-instance FromJSON SubjectAndStatements
-
-instance ToJSON SubjectAndStatements
-
-instance FromJSON Subject
-
-instance ToJSON Subject
-
-instance FromJSON SubjectConfirmation
-
-instance ToJSON SubjectConfirmation
-
-instance FromJSON SubjectConfirmationMethod
-
-instance ToJSON SubjectConfirmationMethod
-
-instance FromJSON SubjectConfirmationData
-
-instance ToJSON SubjectConfirmationData
-
-instance FromJSON IP where
-  parseJSON = withText "IP address" $ either fail pure . mkIP
-
-instance ToJSON IP where
-  toJSON = String . ipToST
-
-instance FromJSON DNSName
-
-instance ToJSON DNSName
-
-instance FromJSON Statement
-
-instance ToJSON Statement
-
-instance FromJSON Locality
-
-instance ToJSON Locality
-
-instance FromJSON (ID a)
-
-instance ToJSON (ID a)
-
-instance FromJSON NameID
-
-instance ToJSON NameID
-
-instance FromJSON Email where
-  parseJSON = withText "email address" $ either fail (pure . Email) . Email.validate . cs
-
-instance ToJSON Email where
-  toJSON = String . cs . Email.toByteString . fromEmail
-
-instance FromJSON UnqualifiedNameID
-
-instance ToJSON UnqualifiedNameID
-
-instance FromJSON Time
-
-instance ToJSON Time
-
-instance FromJSON Conditions
-
-instance ToJSON Conditions
 
 ----------------------------------------------------------------------
 -- hand-crafted lenses, accessors

--- a/src/SAML2/WebSSO/Types/Email.hs
+++ b/src/SAML2/WebSSO/Types/Email.hs
@@ -17,10 +17,10 @@
 module SAML2.WebSSO.Types.Email (Email, render, validate) where
 
 import Data.Aeson
-import Data.ByteString.Internal
+import qualified Data.ByteString as BS
 import qualified Data.CaseInsensitive as CI
 import Data.String.Conversions
-import Data.Text (toLower)
+import Data.Word8 (toLower)
 import qualified Text.Email.Validate as Email
 
 newtype Email = Email {fromEmail :: Email.EmailAddress}
@@ -30,14 +30,14 @@ instance CI.FoldCase Email where
   foldCase (Email eml) =
     Email
       ( Email.unsafeEmailAddress
-          (cs . toLower . cs . Email.localPart $ eml)
-          (cs . toLower . cs . Email.domainPart $ eml)
+          (BS.map toLower . Email.localPart $ eml)
+          (BS.map toLower . Email.domainPart $ eml)
       )
 
-render :: (CI.FoldCase s, ConvertibleStrings ByteString s) => Email -> s
+render :: (CI.FoldCase s, ConvertibleStrings BS.ByteString s) => Email -> s
 render = cs . Email.toByteString . fromEmail
 
-validate :: forall s. ConvertibleStrings s ByteString => s -> Either String (CI.CI Email)
+validate :: forall s. ConvertibleStrings s BS.ByteString => s -> Either String (CI.CI Email)
 validate = fmap (CI.mk . Email) . Email.validate . cs
 
 instance FromJSON (CI.CI Email) where

--- a/src/SAML2/WebSSO/Types/Email.hs
+++ b/src/SAML2/WebSSO/Types/Email.hs
@@ -3,23 +3,44 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}
 
+-- | Email type with case handling options.  This helps mitigate issues with users that get
+-- casing wrong in their email addresses: 'render' is case-sensitive, but `validate' gets you
+-- a case-insensitive value with case information intact, so you are forced to decide for
+-- yourself which version of the email address you want.  Same assymetry for 'FromJSON',
+-- 'ToJSON'.
+--
+-- (The legal situation is simple: [the local part is case
+-- sensitive](https://tools.ietf.org/html/rfc5321), [the domain part is case
+-- insensitive](https://tools.ietf.org/html/rfc1035).  However, in practice, the entire email,
+-- both local and domain part, are treated as case insensitive almost everywhere.  So for
+-- interoperability we want to do the same, but not destroy case information in the process.)
 module SAML2.WebSSO.Types.Email (Email, render, validate) where
 
 import Data.Aeson
 import Data.ByteString.Internal
+import qualified Data.CaseInsensitive as CI
 import Data.String.Conversions
+import Data.Text (toLower)
 import qualified Text.Email.Validate as Email
 
 newtype Email = Email {fromEmail :: Email.EmailAddress}
   deriving (Eq, Ord, Show)
 
-render :: ConvertibleStrings ByteString s => Email -> s
+instance CI.FoldCase Email where
+  foldCase (Email eml) =
+    Email
+      ( Email.unsafeEmailAddress
+          (cs . toLower . cs . Email.localPart $ eml)
+          (cs . toLower . cs . Email.domainPart $ eml)
+      )
+
+render :: (CI.FoldCase s, ConvertibleStrings ByteString s) => Email -> s
 render = cs . Email.toByteString . fromEmail
 
-validate :: forall s. ConvertibleStrings s ByteString => s -> Either String Email
-validate = fmap Email . Email.validate . cs
+validate :: forall s. ConvertibleStrings s ByteString => s -> Either String (CI.CI Email)
+validate = fmap (CI.mk . Email) . Email.validate . cs
 
-instance FromJSON Email where
+instance FromJSON (CI.CI Email) where
   parseJSON = withText "email address" $ either fail pure . validate
 
 instance ToJSON Email where

--- a/src/SAML2/WebSSO/Types/Email.hs
+++ b/src/SAML2/WebSSO/Types/Email.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData #-}
+
+module SAML2.WebSSO.Types.Email (Email, render, validate) where
+
+import Data.Aeson
+import Data.ByteString.Internal
+import Data.String.Conversions
+import qualified Text.Email.Validate as Email
+
+newtype Email = Email {fromEmail :: Email.EmailAddress}
+  deriving (Eq, Ord, Show)
+
+render :: ConvertibleStrings ByteString s => Email -> s
+render = cs . Email.toByteString . fromEmail
+
+validate :: forall s. ConvertibleStrings s ByteString => s -> Either String Email
+validate = fmap Email . Email.validate . cs
+
+instance FromJSON Email where
+  parseJSON = withText "email address" $ either fail pure . validate
+
+instance ToJSON Email where
+  toJSON = String . render

--- a/src/SAML2/WebSSO/Types/Email.hs
+++ b/src/SAML2/WebSSO/Types/Email.hs
@@ -3,10 +3,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}
 
+-- | Case insensitive email type.  This helps mitigate issues with users that get casing wrong
+-- in their email addresses.
+--
+-- (The legal situation is simple: [the local part is case
+-- sensitive](https://tools.ietf.org/html/rfc5321), [the domain part is case
+-- insensitive](https://tools.ietf.org/html/rfc1035).  However, in practice, the entire email,
+-- both local and domain part, are treated as case insensitive almost everywhere.  So for
+-- interoperability we need to do the same.)
 module SAML2.WebSSO.Types.Email (Email, render, validate) where
 
 import Data.Aeson
 import Data.ByteString.Internal
+import Data.CaseInsensitive (foldCase)
 import Data.String.Conversions
 import qualified Text.Email.Validate as Email
 
@@ -17,7 +26,7 @@ render :: ConvertibleStrings ByteString s => Email -> s
 render = cs . Email.toByteString . fromEmail
 
 validate :: forall s. ConvertibleStrings s ByteString => s -> Either String Email
-validate = fmap Email . Email.validate . cs
+validate = fmap Email . Email.validate . foldCase . cs
 
 instance FromJSON Email where
   parseJSON = withText "email address" $ either fail pure . validate

--- a/src/SAML2/WebSSO/Types/Email.hs
+++ b/src/SAML2/WebSSO/Types/Email.hs
@@ -3,19 +3,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}
 
--- | Case insensitive email type.  This helps mitigate issues with users that get casing wrong
--- in their email addresses.
---
--- (The legal situation is simple: [the local part is case
--- sensitive](https://tools.ietf.org/html/rfc5321), [the domain part is case
--- insensitive](https://tools.ietf.org/html/rfc1035).  However, in practice, the entire email,
--- both local and domain part, are treated as case insensitive almost everywhere.  So for
--- interoperability we need to do the same.)
 module SAML2.WebSSO.Types.Email (Email, render, validate) where
 
 import Data.Aeson
 import Data.ByteString.Internal
-import Data.CaseInsensitive (foldCase)
 import Data.String.Conversions
 import qualified Text.Email.Validate as Email
 
@@ -26,7 +17,7 @@ render :: ConvertibleStrings ByteString s => Email -> s
 render = cs . Email.toByteString . fromEmail
 
 validate :: forall s. ConvertibleStrings s ByteString => s -> Either String Email
-validate = fmap Email . Email.validate . foldCase . cs
+validate = fmap Email . Email.validate . cs
 
 instance FromJSON Email where
   parseJSON = withText "email address" $ either fail pure . validate

--- a/src/SAML2/WebSSO/XML.hs
+++ b/src/SAML2/WebSSO/XML.hs
@@ -17,7 +17,6 @@ module SAML2.WebSSO.XML
     unsafeReadTime,
     decodeTime,
     renderTime,
-    userRefToST,
     explainDeniedReason,
     mkSPMetadata,
   )
@@ -152,9 +151,6 @@ renderTime (Time utctime) =
         (t, u) -> case List.splitAt 8 u of
           (_, "") -> t <> u
           (v, _) -> t <> v <> "Z"
-
-userRefToST :: UserRef -> ST
-userRefToST (UserRef (Issuer tenant) subject) = "{" <> renderURI tenant <> "}" <> nameIDToST subject
 
 defAuthnRequest :: HS.ProtocolType -> HS.AuthnRequest
 defAuthnRequest proto =

--- a/src/SAML2/WebSSO/XML.hs
+++ b/src/SAML2/WebSSO/XML.hs
@@ -53,11 +53,11 @@ import qualified SAML2.Profiles as HS
 import SAML2.Util
 import SAML2.WebSSO.SP
 import SAML2.WebSSO.Types
+import qualified SAML2.WebSSO.Types.Email as Email
 import qualified SAML2.XML as HS
 import qualified SAML2.XML as HX
 import qualified SAML2.XML.Schema.Datatypes as HX (Boolean, Duration, UnsignedShort)
 import qualified SAML2.XML.Signature.Types as HX (Signature)
-import qualified Text.Email.Validate as Email
 import Text.Hamlet.XML
 import Text.XML
 import Text.XML.Cursor
@@ -591,7 +591,7 @@ exportNameID name =
     unform (UNameIDUnspecified n) = (HS.Identified HS.NameIDFormatUnspecified, escapeXmlText n)
     unform (UNameIDEmail n) =
       ( HS.Identified HS.NameIDFormatEmail,
-        escapeXmlText . mkXmlText . cs . Email.toByteString $ fromEmail n
+        escapeXmlText . mkXmlText . Email.render $ n
       )
     unform (UNameIDX509 n) = (HS.Identified HS.NameIDFormatX509, escapeXmlText n)
     unform (UNameIDWindows n) = (HS.Identified HS.NameIDFormatWindows, escapeXmlText n)

--- a/src/SAML2/WebSSO/XML.hs
+++ b/src/SAML2/WebSSO/XML.hs
@@ -591,7 +591,7 @@ exportNameID name =
     unform (UNameIDUnspecified n) = (HS.Identified HS.NameIDFormatUnspecified, escapeXmlText n)
     unform (UNameIDEmail n) =
       ( HS.Identified HS.NameIDFormatEmail,
-        escapeXmlText . mkXmlText . Email.render $ n
+        escapeXmlText . mkXmlText . Email.render . CI.original $ n
       )
     unform (UNameIDX509 n) = (HS.Identified HS.NameIDFormatX509, escapeXmlText n)
     unform (UNameIDWindows n) = (HS.Identified HS.NameIDFormatWindows, escapeXmlText n)

--- a/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/test/Test/SAML2/WebSSO/APISpec.hs
@@ -194,7 +194,7 @@ spec = describe "API" $ do
         testAuthRespApp =
           withapp
             (Proxy @APIAuthResp')
-            (authresp' defSPIssuer defResponseURI (HandleVerdictRedirect simpleOnSuccess))
+            (authresp' defSPIssuer defResponseURI (HandleVerdictRedirect (simpleOnSuccess SubjectFoldCase)))
 
     context "unknown idp" . testAuthRespApp mkTestCtxSimple $ do
       it "responds with 404" . runtest $ \ctx -> do

--- a/test/Test/SAML2/WebSSO/XML/ExamplesSpec.hs
+++ b/test/Test/SAML2/WebSSO/XML/ExamplesSpec.hs
@@ -12,6 +12,7 @@ import Control.Monad (forM_)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader
 import qualified Data.ByteString.Base64.Lazy as EL (decodeLenient)
+import qualified Data.CaseInsensitive as CI
 import Data.Either
 import qualified Data.List as List
 import Data.List.NonEmpty as NL
@@ -90,7 +91,7 @@ spec = describe "XML serialization" $ do
             Just subj -> do
               parsed `shouldSatisfy` isRight
               let Right (subjid :: NameID) = parsed <&> (^. assertionL . assContents . sasSubject . subjectID)
-              shortShowNameID subjid `shouldBe` Just subj
+              (CI.original <$> shortShowNameID subjid) `shouldBe` Just subj
         mknid = NodeElement . Element "{urn:oasis:names:tc:SAML:2.0:assertion}NameID" mempty
     check
       "good"


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-229

If we agree this is a good idea, we need to think about what happens if we try to search for the email address on brig, should find it there, but it contains capitalized letters.

A conservative change would be to add a query param to the search end-point that turns on case insensitive search.  But that may not be a trivial change and require ES migrations, need to look into that.

A more drastic (and possible better) change would be to make [brig's email type](https://hoogle.zinfra.io/file/wire-server/.stack-work/install/x86_64-linux/e00ba0ce2b6f336dd3c149eea3af918dee7810ea4744bc044e74e59fcf387fc6/8.8.4/doc/wire-api-0.1.0/Wire-API-User-Identity.html#t:Email) also case-insensitive (and all the other email types we're using in brig).