### PR TITLE
multi-app service providers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ You need:
 Now run:
 
 ```
+export SAML2_WEB_SSO_ROOT=`pwd`
 stack test --fast
-SAML2_WEB_SSO_ROOT=`pwd` stack exec toy-sp
+stack exec toy-sp
 ```
 
 This should start the `toy-sp` app.  Now you can connect to

--- a/src/SAML2/WebSSO/API.hs
+++ b/src/SAML2/WebSSO/API.hs
@@ -136,7 +136,7 @@ instance FromMultipart Mem AuthnResponseBody where
 issuerToCreds :: forall m err. SPStoreIdP (Error err) m => Maybe Issuer -> Maybe (IdPConfigSPId m) -> m (NonEmpty SignCreds)
 issuerToCreds Nothing _ = throwError BadSamlResponseIssuerMissing
 issuerToCreds (Just issuer) mbSPId = do
-  certs <- (^. idpMetadata . edCertAuthnResponse) <$> getIdPConfigByIssuer issuer mbSPId
+  certs <- (^. idpMetadata . edCertAuthnResponse) <$> getIdPConfigByIssuerOptionalSPId issuer mbSPId
   let err = throwError . InvalidCert . ((encodeElem issuer <> ": ") <>) . cs
   forM certs $ either err pure . certToCreds
 

--- a/src/SAML2/WebSSO/API.hs
+++ b/src/SAML2/WebSSO/API.hs
@@ -79,7 +79,7 @@ api :: forall err m. SPHandler (Error err) m => ST -> HandleVerdict m -> ServerT
 api appName handleVerdict =
   meta appName defSPIssuer defResponseURI
     :<|> authreq' defSPIssuer
-    :<|> authresp' defSPIssuer defResponseURI handleVerdict
+    :<|> authresp' Nothing {- this is a lazy short-cut: no SPIds expected in this API -} defSPIssuer defResponseURI handleVerdict
 
 -- | The 'Issuer' is an identifier of a SAML participant.  In this case, it's the SP, ie.,
 -- ourselves.  For simplicity, we re-use the response URI here.
@@ -93,10 +93,11 @@ defResponseURI = getSsoURI (Proxy @API) (Proxy @APIAuthResp')
 ----------------------------------------------------------------------
 -- authentication response body processing
 
--- | An 'AuthnResponseBody' contains a 'AuthnResponse', but you need to give it a trust base for
--- signature verification first, and you may get an error when you're looking at it.
+-- | An 'AuthnResponseBody' contains a 'AuthnResponse', but you need to give it an SPId for
+-- IdP lookup and trust base for signature verification first, plus you may get an error when
+-- you're looking at it.
 data AuthnResponseBody = AuthnResponseBody
-  { authnResponseBodyAction :: forall m err. SPStoreIdP (Error err) m => m AuthnResponse,
+  { authnResponseBodyAction :: forall m err. SPStoreIdP (Error err) m => Maybe (IdPConfigSPId m) -> m AuthnResponse,
     authnResponseBodyRaw :: MultipartData Mem
   }
 
@@ -104,8 +105,8 @@ renderAuthnResponseBody :: AuthnResponse -> LBS
 renderAuthnResponseBody = EL.encode . cs . encode
 
 -- | Implies verification, hence the constraint.
-parseAuthnResponseBody :: forall m err. SPStoreIdP (Error err) m => ST -> m AuthnResponse
-parseAuthnResponseBody base64 = do
+parseAuthnResponseBody :: forall m err. SPStoreIdP (Error err) m => Maybe (IdPConfigSPId m) -> ST -> m AuthnResponse
+parseAuthnResponseBody mbSPId base64 = do
   -- https://www.ietf.org/rfc/rfc4648.txt states that all "noise" characters should be rejected
   -- unless another standard says they should be ignored.  'EL.decodeLenient' chooses the radical
   -- approach and ignores all "noise" characters.  since we have to deal with at least %0a, %0d%0a,
@@ -115,7 +116,7 @@ parseAuthnResponseBody base64 = do
   resp <-
     either (throwError . BadSamlResponseXmlError . cs) pure $
       decode (cs xmltxt)
-  creds <- issuerToCreds (resp ^. rspIssuer)
+  creds <- issuerToCreds (resp ^. rspIssuer) mbSPId
   simpleVerifyAuthnResponse creds xmltxt
   pure resp
 
@@ -125,17 +126,17 @@ authnResponseBodyToMultipart resp = MultipartData [Input "SAMLResponse" (cs $ re
 instance FromMultipart Mem AuthnResponseBody where
   fromMultipart resp = Just (AuthnResponseBody eval resp)
     where
-      eval :: forall m err. SPStoreIdP (Error err) m => m AuthnResponse
-      eval = do
+      eval :: forall m err. SPStoreIdP (Error err) m => Maybe (IdPConfigSPId m) -> m AuthnResponse
+      eval mbSPId = do
         base64 <-
           maybe (throwError BadSamlResponseFormFieldMissing) pure $
             lookupInput "SAMLResponse" resp
-        parseAuthnResponseBody base64
+        parseAuthnResponseBody mbSPId base64
 
-issuerToCreds :: forall m err. SPStoreIdP (Error err) m => Maybe Issuer -> m (NonEmpty SignCreds)
-issuerToCreds Nothing = throwError BadSamlResponseIssuerMissing
-issuerToCreds (Just issuer) = do
-  certs <- (^. idpMetadata . edCertAuthnResponse) <$> getIdPConfigByIssuer issuer
+issuerToCreds :: forall m err. SPStoreIdP (Error err) m => Maybe Issuer -> Maybe (IdPConfigSPId m) -> m (NonEmpty SignCreds)
+issuerToCreds Nothing _ = throwError BadSamlResponseIssuerMissing
+issuerToCreds (Just issuer) mbSPId = do
+  certs <- (^. idpMetadata . edCertAuthnResponse) <$> getIdPConfigByIssuer issuer mbSPId
   let err = throwError . InvalidCert . ((encodeElem issuer <> ": ") <>) . cs
   forM certs $ either err pure . certToCreds
 
@@ -281,15 +282,16 @@ defReqTTL = 15 * 60 -- seconds
 -- 'm' and return anything it likes.
 authresp ::
   (SP m, SPStoreIdP (Error err) m, SPStoreID Assertion m, SPStoreID AuthnRequest m) =>
+  Maybe (IdPConfigSPId m) ->
   m Issuer ->
   m URI ->
   (AuthnResponse -> AccessVerdict -> m resp) ->
   AuthnResponseBody ->
   m resp
-authresp getSPIssuer getResponseURI handleVerdictAction body = do
+authresp mbSPId getSPIssuer getResponseURI handleVerdictAction body = do
   enterH "authresp: entering"
   jctx :: JudgeCtx <- JudgeCtx <$> getSPIssuer <*> getResponseURI
-  resp :: AuthnResponse <- authnResponseBodyAction body
+  resp :: AuthnResponse <- authnResponseBodyAction body mbSPId
   logger Debug $ "authresp: " <> ppShow resp
   verdict <- judge resp jctx
   logger Debug $ "authresp: " <> show verdict
@@ -298,16 +300,17 @@ authresp getSPIssuer getResponseURI handleVerdictAction body = do
 -- | a variant of 'authresp' with a less general verdict handler.
 authresp' ::
   (SP m, SPStoreIdP (Error err) m, SPStoreID Assertion m, SPStoreID AuthnRequest m) =>
+  Maybe (IdPConfigSPId m) ->
   m Issuer ->
   m URI ->
   HandleVerdict m ->
   AuthnResponseBody ->
   m (WithCookieAndLocation ST)
-authresp' getRequestIssuerURI getResponseURI handleVerdict body = do
+authresp' mbSPId getRequestIssuerURI getResponseURI handleVerdict body = do
   let handleVerdictAction resp verdict = case handleVerdict of
         HandleVerdictRedirect onsuccess -> simpleHandleVerdict onsuccess verdict
         HandleVerdictRaw action -> throwError . CustomServant =<< action resp verdict
-  authresp getRequestIssuerURI getResponseURI handleVerdictAction body
+  authresp mbSPId getRequestIssuerURI getResponseURI handleVerdictAction body
 
 type OnSuccessRedirect m = UserRef -> m (Cky, URI)
 

--- a/src/SAML2/WebSSO/API/Example.hs
+++ b/src/SAML2/WebSSO/API/Example.hs
@@ -127,7 +127,7 @@ instance SPStoreIdP SimpleError SimpleSP where
   type IdPConfigSPId SimpleSP = Void
   storeIdPConfig _ = error "instance SPStoreIdP SimpleError SimpleSP: storeIdPConfig not implemented."
   getIdPConfig = simpleGetIdPConfigBy (asks (^. spctxIdP)) (^. idpId)
-  getIdPConfigByIssuer issuer _ = simpleGetIdPConfigBy (asks (^. spctxIdP)) (^. idpMetadata . edIssuer) issuer
+  getIdPConfigByIssuerOptionalSPId issuer _ = simpleGetIdPConfigBy (asks (^. spctxIdP)) (^. idpMetadata . edIssuer) issuer
 
 simpleGetIdPConfigBy ::
   (MonadError (Error err) m, HasConfig m, Show a, Ord a) =>

--- a/src/SAML2/WebSSO/API/Example.hs
+++ b/src/SAML2/WebSSO/API/Example.hs
@@ -17,6 +17,7 @@ import Data.Map as Map
 import Data.Proxy
 import Data.String.Conversions
 import Data.UUID as UUID
+import Data.Void (Void)
 import GHC.Stack
 import Network.Wai hiding (Response)
 import SAML2.Util
@@ -123,9 +124,10 @@ instance HasConfig SimpleSP where
 
 instance SPStoreIdP SimpleError SimpleSP where
   type IdPConfigExtra SimpleSP = ()
+  type IdPConfigSPId SimpleSP = Void
   storeIdPConfig _ = error "instance SPStoreIdP SimpleError SimpleSP: storeIdPConfig not implemented."
   getIdPConfig = simpleGetIdPConfigBy (asks (^. spctxIdP)) (^. idpId)
-  getIdPConfigByIssuer = simpleGetIdPConfigBy (asks (^. spctxIdP)) (^. idpMetadata . edIssuer)
+  getIdPConfigByIssuer issuer _ = simpleGetIdPConfigBy (asks (^. spctxIdP)) (^. idpMetadata . edIssuer) issuer
 
 simpleGetIdPConfigBy ::
   (MonadError (Error err) m, HasConfig m, Show a, Ord a) =>

--- a/src/SAML2/WebSSO/SP.hs
+++ b/src/SAML2/WebSSO/SP.hs
@@ -61,7 +61,9 @@ class (MonadError err m) => SPStoreIdP err m where
   type IdPConfigSPId m :: Type
   storeIdPConfig :: IdPConfig (IdPConfigExtra m) -> m ()
   getIdPConfig :: IdPId -> m (IdPConfig (IdPConfigExtra m))
-  getIdPConfigByIssuer :: Issuer -> Maybe (IdPConfigSPId m) -> m (IdPConfig (IdPConfigExtra m))
+  getIdPConfigByIssuer :: Issuer -> IdPConfigSPId m -> m (IdPConfig (IdPConfigExtra m))
+  getIdPConfigByIssuer issuer spid = getIdPConfigByIssuerOptionalSPId issuer (Just spid)
+  getIdPConfigByIssuerOptionalSPId :: Issuer -> Maybe (IdPConfigSPId m) -> m (IdPConfig (IdPConfigExtra m))
 
 -- | HTTP handling of the service provider.
 class (SP m, SPStore m, SPStoreIdP err m, MonadError err m) => SPHandler err m where

--- a/src/SAML2/WebSSO/SP.hs
+++ b/src/SAML2/WebSSO/SP.hs
@@ -58,9 +58,10 @@ class SPStoreID i m where
 
 class (MonadError err m) => SPStoreIdP err m where
   type IdPConfigExtra m :: Type
+  type IdPConfigSPId m :: Type
   storeIdPConfig :: IdPConfig (IdPConfigExtra m) -> m ()
   getIdPConfig :: IdPId -> m (IdPConfig (IdPConfigExtra m))
-  getIdPConfigByIssuer :: Issuer -> m (IdPConfig (IdPConfigExtra m))
+  getIdPConfigByIssuer :: Issuer -> Maybe (IdPConfigSPId m) -> m (IdPConfig (IdPConfigExtra m))
 
 -- | HTTP handling of the service provider.
 class (SP m, SPStore m, SPStoreIdP err m, MonadError err m) => SPHandler err m where

--- a/src/SAML2/WebSSO/Test/Arbitrary.hs
+++ b/src/SAML2/WebSSO/Test/Arbitrary.hs
@@ -492,7 +492,7 @@ genAuthnResponseBody :: Gen AuthnResponseBody
 genAuthnResponseBody = do
   aresp <- genAuthnResponse
   raw <- genRawAuthnResponseBody
-  pure (AuthnResponseBody (pure aresp) raw)
+  pure (AuthnResponseBody (\_ -> pure aresp) raw)
 
 genRawAuthnResponseBody :: Gen (MultipartData Mem)
 genRawAuthnResponseBody = do

--- a/src/SAML2/WebSSO/Test/Util/TestSP.hs
+++ b/src/SAML2/WebSSO/Test/Util/TestSP.hs
@@ -17,6 +17,7 @@ import Data.Maybe
 import Data.Time
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
+import Data.Void (Void)
 import Network.Wai.Test (runSession)
 import SAML2.WebSSO as SAML
 import SAML2.WebSSO.API.Example (GetAllIdPs (..), simpleGetIdPConfigBy, simpleIsAliveID', simpleStoreID', simpleUnStoreID')
@@ -95,9 +96,10 @@ instance SPStoreID Assertion TestSP where
 
 instance SPStoreIdP SimpleError TestSP where
   type IdPConfigExtra TestSP = ()
+  type IdPConfigSPId TestSP = Void -- FUTUREWORK: can we do better than this?
   storeIdPConfig _ = pure ()
   getIdPConfig = simpleGetIdPConfigBy readIdPs (^. idpId)
-  getIdPConfigByIssuer = simpleGetIdPConfigBy readIdPs (^. idpMetadata . edIssuer)
+  getIdPConfigByIssuer issuer _ = simpleGetIdPConfigBy readIdPs (^. idpMetadata . edIssuer) issuer
 
 instance GetAllIdPs SimpleError TestSP where
   getAllIdPs = fmap fst . (^. ctxIdPs) <$> (ask >>= liftIO . readMVar)

--- a/src/SAML2/WebSSO/Test/Util/TestSP.hs
+++ b/src/SAML2/WebSSO/Test/Util/TestSP.hs
@@ -99,7 +99,7 @@ instance SPStoreIdP SimpleError TestSP where
   type IdPConfigSPId TestSP = Void -- FUTUREWORK: can we do better than this?
   storeIdPConfig _ = pure ()
   getIdPConfig = simpleGetIdPConfigBy readIdPs (^. idpId)
-  getIdPConfigByIssuer issuer _ = simpleGetIdPConfigBy readIdPs (^. idpMetadata . edIssuer) issuer
+  getIdPConfigByIssuerOptionalSPId issuer _ = simpleGetIdPConfigBy readIdPs (^. idpMetadata . edIssuer) issuer
 
 instance GetAllIdPs SimpleError TestSP where
   getAllIdPs = fmap fst . (^. ctxIdPs) <$> (ask >>= liftIO . readMVar)

--- a/src/SAML2/WebSSO/Test/Util/VendorCompatibility.hs
+++ b/src/SAML2/WebSSO/Test/Util/VendorCompatibility.hs
@@ -31,7 +31,7 @@ testAuthRespApp :: HasCallStack => URI.URI -> SpecWith (CtxV, Application) -> Sp
 testAuthRespApp ssoURI =
   withapp
     (Proxy @("sso" :> APIAuthResp'))
-    (authresp' spissuer respuri (HandleVerdictRedirect (simpleOnSuccess SubjectFoldCase)))
+    (authresp' Nothing spissuer respuri (HandleVerdictRedirect (simpleOnSuccess SubjectFoldCase)))
     mkTestCtxSimple
   where
     spissuer = Issuer <$> respuri

--- a/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/test/Test/SAML2/WebSSO/APISpec.hs
@@ -118,7 +118,7 @@ spec = describe "API" $ do
                 missuer = (^. _1 . idpMetadata . edIssuer) <$> midpcfg
                 go :: TestSP ()
                 go = do
-                  creds <- issuerToCreds missuer
+                  creds <- issuerToCreds missuer Nothing
                   simpleVerifyAuthnResponse creds resp
             if expectOutcome
               then run go `shouldReturn` ()
@@ -194,7 +194,7 @@ spec = describe "API" $ do
         testAuthRespApp =
           withapp
             (Proxy @APIAuthResp')
-            (authresp' defSPIssuer defResponseURI (HandleVerdictRedirect (simpleOnSuccess SubjectFoldCase)))
+            (authresp' Nothing defSPIssuer defResponseURI (HandleVerdictRedirect (simpleOnSuccess SubjectFoldCase)))
 
     context "unknown idp" . testAuthRespApp mkTestCtxSimple $ do
       it "responds with 404" . runtest $ \ctx -> do
@@ -235,7 +235,7 @@ spec = describe "API" $ do
             SignedAuthnResponse authnrespDoc <-
               liftIO . ioFromTestSP ctx $ mkAuthnResponse privkey (idpcfg ^. _1) spmeta authnreq True
             let authnrespLBS = renderLBS def authnrespDoc
-            creds <- issuerToCreds (Just idpissuer)
+            creds <- issuerToCreds (Just idpissuer) Nothing
             simpleVerifyAuthnResponse creds authnrespLBS
           result `shouldSatisfy` expectation
     it "Produces output that passes 'simpleVerifyAuthnResponse'" $ do

--- a/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/test/Test/SAML2/WebSSO/APISpec.hs
@@ -247,7 +247,7 @@ spec = describe "API" $ do
     let parseSample :: FilePath -> IO (Either String IdPMetadata)
         parseSample samplePath = decode <$> readSampleIO samplePath
 
-    it "fails with helpful error message if HTTP-POST is missing" $ do
+    it "fails with helpful error message if HTTP-POST is missing (eg., if only HTTP-Redirect is provided)" $ do
       res <- parseSample "post-missing.xml"
       res `shouldBe` Left "Couldnt find any matches for: \"Binding\" attribute with value \"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\""
 

--- a/test/Test/SAML2/WebSSO/XML/ExamplesSpec.hs
+++ b/test/Test/SAML2/WebSSO/XML/ExamplesSpec.hs
@@ -92,7 +92,10 @@ spec = describe "XML serialization" $ do
               parsed `shouldSatisfy` isRight
               let Right (subjid :: NameID) = parsed <&> (^. assertionL . assContents . sasSubject . subjectID)
               (CI.original <$> shortShowNameID subjid) `shouldBe` Just subj
+
+        mknid :: [Node] -> Node
         mknid = NodeElement . Element "{urn:oasis:names:tc:SAML:2.0:assertion}NameID" mempty
+
     check
       "good"
       [mknid [NodeContent "xkcd"]]

--- a/test/Test/SAML2/WebSSO/XMLSpec.hs
+++ b/test/Test/SAML2/WebSSO/XMLSpec.hs
@@ -99,15 +99,15 @@ spec = describe "XML Sanitization" $ do
       -- this test case reproduces an issue with hsaml2 that motivates us manually escaping
       -- the 'XmlText's in the serialization functions here in saml2-web-sso.
 
+      -- it really shouldn't, though!
       HS.samlToXML (HS.simpleNameID HS.NameIDFormatUnspecified "<something>")
         `shouldBe` "<NameID xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\"><something></NameID>"
-      -- it really shouldn't, though!
 
+      -- this is good!
       HS.xmlToSAML @HS.NameID "<NameID xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\"><something></NameID>"
         `shouldSatisfy` isLeft
-      -- this is good!
 
+      -- this is good!
       HS.xmlToSAML @HS.NameID "<NameID xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\">&lt;something&gt;</NameID>"
         `shouldBe` Right (HS.simpleNameID HS.NameIDFormatUnspecified "<something>")
 
--- this is good!


### PR DESCRIPTION
There are IdPs out there that refuse to present itself under different entityID/Issuer to different apps.  In order to accommodate these IdPs and still allow to run several apps (think: groups, teams, ...) in one executable with this library, this PR adds support for SP ids.

An IdP can talk to a single executable linking against saml2-web-sso using different SP ids, and thus using the same entityID to provide authentication to different apps hosted by that executable.