### PR TITLE
Build with stackage snapshot 18.18

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -75,7 +75,7 @@ dependencies:
   - network-uri >=2.6.1.0
   - random >=1.1
   - servant >=0.16.2
-  - servant-multipart >=0.11.4
+  - servant-multipart >=0.12
   - servant-server >=0.16.2
   - silently >=1.2.5.1
   - string-conversions >=0.4.0.1

--- a/saml2-web-sso.cabal
+++ b/saml2-web-sso.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 75e35512ef3af4dae35ff34a07647dd316348c29640c2c3d64479d061a9c31cd
+-- hash: 2dbbf1c82946326cc2199fc787becd8e252feeacb3356aae63bc5b63d0fe35f4
 
 name:           saml2-web-sso
 version:        0.18
@@ -49,7 +49,33 @@ library
       Paths_saml2_web_sso
   hs-source-dirs:
       src
-  default-extensions: NoOverloadedStrings ConstraintKinds DataKinds DefaultSignatures DeriveGeneric FlexibleContexts FlexibleInstances GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses NoMonomorphismRestriction PolyKinds QuasiQuotes RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances ViewPatterns
+  default-extensions:
+      NoOverloadedStrings
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveGeneric
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      NoMonomorphismRestriction
+      PolyKinds
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -j -O2 -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wtabs -Werror
   build-depends:
       QuickCheck >=2.13.2
@@ -94,7 +120,7 @@ library
     , quickcheck-instances >=0.3.22
     , random >=1.1
     , servant >=0.16.2
-    , servant-multipart >=0.11.4
+    , servant-multipart >=0.12
     , servant-server >=0.16.2
     , shelly >=1.8.1
     , silently >=1.2.5.1
@@ -124,7 +150,33 @@ executable toy-sp
       Paths_saml2_web_sso
   hs-source-dirs:
       toy-sp
-  default-extensions: NoOverloadedStrings ConstraintKinds DataKinds DefaultSignatures DeriveGeneric FlexibleContexts FlexibleInstances GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses NoMonomorphismRestriction PolyKinds QuasiQuotes RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances ViewPatterns
+  default-extensions:
+      NoOverloadedStrings
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveGeneric
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      NoMonomorphismRestriction
+      PolyKinds
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -j -O2 -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wtabs -Werror
   build-depends:
       QuickCheck >=2.13.2
@@ -170,7 +222,7 @@ executable toy-sp
     , random >=1.1
     , saml2-web-sso
     , servant >=0.16.2
-    , servant-multipart >=0.11.4
+    , servant-multipart >=0.12
     , servant-server >=0.16.2
     , shelly >=1.8.1
     , silently >=1.2.5.1
@@ -213,7 +265,33 @@ test-suite spec
       Paths_saml2_web_sso
   hs-source-dirs:
       test
-  default-extensions: NoOverloadedStrings ConstraintKinds DataKinds DefaultSignatures DeriveGeneric FlexibleContexts FlexibleInstances GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses NoMonomorphismRestriction PolyKinds QuasiQuotes RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances ViewPatterns
+  default-extensions:
+      NoOverloadedStrings
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveGeneric
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      NoMonomorphismRestriction
+      PolyKinds
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -j -O2 -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wtabs -Werror -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck >=2.13.2
@@ -261,7 +339,7 @@ test-suite spec
     , random >=1.1
     , saml2-web-sso
     , servant >=0.16.2
-    , servant-multipart >=0.11.4
+    , servant-multipart >=0.12
     , servant-server >=0.16.2
     , shelly >=1.8.1
     , silently >=1.2.5.1

--- a/src/SAML2/WebSSO/API.hs
+++ b/src/SAML2/WebSSO/API.hs
@@ -124,12 +124,12 @@ authnResponseBodyToMultipart :: AuthnResponse -> MultipartData tag
 authnResponseBodyToMultipart resp = MultipartData [Input "SAMLResponse" (cs $ renderAuthnResponseBody resp)] []
 
 instance FromMultipart Mem AuthnResponseBody where
-  fromMultipart resp = Just (AuthnResponseBody eval resp)
+  fromMultipart resp = Right (AuthnResponseBody eval resp)
     where
       eval :: forall m err. SPStoreIdP (Error err) m => Maybe (IdPConfigSPId m) -> m AuthnResponse
       eval mbSPId = do
         base64 <-
-          maybe (throwError BadSamlResponseFormFieldMissing) pure $
+          either (const $ throwError BadSamlResponseFormFieldMissing) pure $
             lookupInput "SAMLResponse" resp
         parseAuthnResponseBody mbSPId base64
 

--- a/src/SAML2/WebSSO/Servant.hs
+++ b/src/SAML2/WebSSO/Servant.hs
@@ -8,7 +8,7 @@ where
 
 import Data.EitherR
 import Data.Function
-import Data.List
+import Data.List (nubBy)
 import qualified Data.Map as Map
 import Data.Proxy
 import Data.String.Conversions

--- a/src/SAML2/WebSSO/Test/Util/Misc.hs
+++ b/src/SAML2/WebSSO/Test/Util/Misc.hs
@@ -9,7 +9,7 @@ import Control.Monad.IO.Class
 import qualified Data.ByteString.Base64.Lazy as EL (encode)
 import Data.EitherR
 import Data.Generics.Uniplate.Data
-import Data.List
+import Data.List (sort)
 import Data.String
 import Data.String.Conversions
 import qualified Data.Text.Lazy.IO as LT

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.14
+resolver: lts-18.18
 
 packages:
 - .
@@ -9,7 +9,6 @@ extra-deps:
 - git: https://github.com/wireapp/hspec-wai
   commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25  # https://github.com/hspec/hspec-wai/pull/49
 - invertible-hxt-0.1  # for hsaml2
-- servant-multipart-0.11.5 # Dropped from stackage
 
 - ormolu-0.1.4.1
 - ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751  # for ormolu

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -34,13 +34,6 @@ packages:
   original:
     hackage: invertible-hxt-0.1
 - completed:
-    hackage: servant-multipart-0.11.5@sha256:1633f715b5b53d648a1da69839bdc5046599f4f7244944d4bbf852dba38d8f4b,2319
-    pantry-tree:
-      size: 333
-      sha256: b3e1fd2ad2e654475be000c2f0ac6f717b5499436fa73eec50ceccddf352dcec
-  original:
-    hackage: servant-multipart-0.11.5
-- completed:
     hackage: ormolu-0.1.4.1@sha256:2381482127734d1897cdb8a191033ef40e4d1bdc3c9af31bd6ef2b8d5ce5429a,6292
     pantry-tree:
       size: 74141
@@ -56,7 +49,7 @@ packages:
     hackage: ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751
 snapshots:
 - completed:
-    size: 532382
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/14.yaml
-    sha256: 1ef27e36f38824abafc43224ca612211b3828fa9ffd31ba0fc2867ae2e19ba90
-  original: lts-16.14
+    size: 586296
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
+    sha256: 63539429076b7ebbab6daa7656cfb079393bf644971156dc349d7c0453694ac2
+  original: lts-18.18


### PR DESCRIPTION
This change requires servant-multipart to be at least 0.12 as it
introduced a breaking change to FromMultipart typeclass.

The cabal files got updated due to latest stack (2.7.3).