### PR TITLE
Make result of signature verification more informative for app.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:          saml2-web-sso
-version:       '0.18'
+version:       '0.19'
 synopsis:      'Library and example web app for the SAML Web-based SSO profile.'
 author:        Wire Swiss GmbH
 maintainer:    Wire Swiss GmbH <backend@wire.com>

--- a/saml2-web-sso.cabal
+++ b/saml2-web-sso.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2dbbf1c82946326cc2199fc787becd8e252feeacb3356aae63bc5b63d0fe35f4
+-- hash: 98e0ba4505ff584cbb9ff97b304b0ee5796e3e501ccace8b4ca2d904bf01c7dd
 
 name:           saml2-web-sso
-version:        0.18
+version:        0.19
 synopsis:       Library and example web app for the SAML Web-based SSO profile.
 description:    See README.md
 category:       System

--- a/src/SAML2/WebSSO/Test/Arbitrary.hs
+++ b/src/SAML2/WebSSO/Test/Arbitrary.hs
@@ -488,11 +488,17 @@ genSimpleSetCookie = do
         setCookieSameSite = samesite
       }
 
+{-
+-- FUTUREWORK: this would be much more possible to implement if 'AuthnResponseBody' would be
+-- defined with type parameters rather than existentially quantified types in
+-- 'authnResponseBodyAction'.)
 genAuthnResponseBody :: Gen AuthnResponseBody
 genAuthnResponseBody = do
   aresp <- genAuthnResponse
+  idp <- genIdPConfig (pure ())
   raw <- genRawAuthnResponseBody
-  pure (AuthnResponseBody (\_ -> pure aresp) raw)
+  pure (AuthnResponseBody (\_ -> pure (aresp, idp)) raw)
+-}
 
 genRawAuthnResponseBody :: Gen (MultipartData Mem)
 genRawAuthnResponseBody = do

--- a/test/Test/SAML2/WebSSO/RoundtripSpec.hs
+++ b/test/Test/SAML2/WebSSO/RoundtripSpec.hs
@@ -8,7 +8,7 @@ where
 
 import Control.Lens
 import Data.Aeson as Aeson
-import Data.List
+import Data.List (sort)
 import qualified Data.List.NonEmpty as NL
 import Data.Proxy
 import Hedgehog


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1630

Signature verification now returns more data about IdP so app doesn't have to look it up again.