### PR TITLE
Make compatible with hspec-wai 0.11.1

### DIFF
--- a/saml2-web-sso.cabal
+++ b/saml2-web-sso.cabal
@@ -111,7 +111,6 @@ library
     , http-types >=0.12.3
     , hxt >=9.3.1.18
     , lens >=4.17.1
-    , lens-datetime >=0.3
     , memory >=0.14.18
     , mtl >=2.2.2
     , network-uri >=2.6.1.0
@@ -212,7 +211,6 @@ executable toy-sp
     , http-types >=0.12.3
     , hxt >=9.3.1.18
     , lens >=4.17.1
-    , lens-datetime >=0.3
     , memory >=0.14.18
     , mtl >=2.2.2
     , network-uri >=2.6.1.0
@@ -329,7 +327,6 @@ test-suite spec
     , http-types >=0.12.3
     , hxt >=9.3.1.18
     , lens >=4.17.1
-    , lens-datetime >=0.3
     , memory >=0.14.18
     , mtl >=2.2.2
     , network-uri >=2.6.1.0

--- a/src/SAML2/WebSSO/Types.hs
+++ b/src/SAML2/WebSSO/Types.hs
@@ -787,9 +787,9 @@ instance Servant.FromHttpApiData IdPId where
 instance Servant.ToHttpApiData IdPId where
   toUrlPiece = idPIdToST
 
-deriveJSON deriveJSONOptions ''ContactPerson
-
 deriveJSON deriveJSONOptions ''ContactType
+
+deriveJSON deriveJSONOptions ''ContactPerson
 
 instance Servant.FromHttpApiData (ID a) where
   parseUrlPiece = fmap (ID . mkXmlText) . Servant.parseUrlPiece

--- a/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/test/Test/SAML2/WebSSO/APISpec.hs
@@ -174,7 +174,7 @@ spec = describe "API" $ do
     let -- Create an AuthnRequest in the SP, then call 'mkAuthnResponse' to make an 'AuthnResponse'
         -- in the IdP, then post the 'AuthnResponse' to the appropriate SP end-point.  @spmeta@ is
         -- needed for making the 'AuthnResponse'.
-        postTestAuthnResp :: HasCallStack => CtxV -> Bool -> Bool -> WaiSession SResponse
+        postTestAuthnResp :: HasCallStack => CtxV -> Bool -> Bool -> WaiSession st SResponse
         postTestAuthnResp ctxv badIdP badTimeStamp = do
           aresp <- liftIO . ioFromTestSP ctxv $ do
             (testIdPConfig, SampleIdP _ privkey _ _) <- do


### PR DESCRIPTION
Motivation for this PR is to make `saml2-web-sso` compile with ghc 9.2 and newer packages. Some tests fail locally because environment variables are not set.

- Make compatible with hspec-wai 0.11.1
- Remove dependency on lens-datetime
- fix compliation issue for 9.2
