### PR TITLE
Updated cryptonite to crypton

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -54,7 +54,7 @@ dependencies:
   - case-insensitive >= 1.2.1.0
   - containers >=0.6.0.1
   - cookie >=0.4.4
-  - cryptonite >=0.25
+  - crypton >=0.30
   - data-default >=0.7.1.1
   - directory >=1.3.6.0
   - dns >=4.0.0
@@ -88,7 +88,7 @@ dependencies:
   - wai >=3.2.2.1
   - warp >=3.2.28
   - word8 >=0.1.3
-  - x509 >=1.7.5
+  - crypton-x509 >=1.7.5
   - xml-conduit >=1.8.0.1
   - xml-conduit-writer >=0.1.1.2
   - xml-hamlet >=0.5.0.1

--- a/saml2-web-sso.cabal
+++ b/saml2-web-sso.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 98e0ba4505ff584cbb9ff97b304b0ee5796e3e501ccace8b4ca2d904bf01c7dd
 
 name:           saml2-web-sso
 version:        0.19
@@ -90,7 +88,8 @@ library
     , case-insensitive >=1.2.1.0
     , containers >=0.6.0.1
     , cookie >=0.4.4
-    , cryptonite >=0.25
+    , crypton >=0.30
+    , crypton-x509 >=1.7.5
     , data-default >=0.7.1.1
     , directory >=1.3.6.0
     , dns >=4.0.0
@@ -111,6 +110,7 @@ library
     , http-types >=0.12.3
     , hxt >=9.3.1.18
     , lens >=4.17.1
+    , lens-datetime >=0.3
     , memory >=0.14.18
     , mtl >=2.2.2
     , network-uri >=2.6.1.0
@@ -135,7 +135,6 @@ library
     , wai-extra >=3.0.28
     , warp >=3.2.28
     , word8 >=0.1.3
-    , x509 >=1.7.5
     , xml-conduit >=1.8.0.1
     , xml-conduit-writer >=0.1.1.2
     , xml-hamlet >=0.5.0.1
@@ -190,7 +189,8 @@ executable toy-sp
     , case-insensitive >=1.2.1.0
     , containers >=0.6.0.1
     , cookie >=0.4.4
-    , cryptonite >=0.25
+    , crypton >=0.30
+    , crypton-x509 >=1.7.5
     , data-default >=0.7.1.1
     , directory >=1.3.6.0
     , dns >=4.0.0
@@ -211,6 +211,7 @@ executable toy-sp
     , http-types >=0.12.3
     , hxt >=9.3.1.18
     , lens >=4.17.1
+    , lens-datetime >=0.3
     , memory >=0.14.18
     , mtl >=2.2.2
     , network-uri >=2.6.1.0
@@ -236,7 +237,6 @@ executable toy-sp
     , wai-extra >=3.0.28
     , warp >=3.2.28
     , word8 >=0.1.3
-    , x509 >=1.7.5
     , xml-conduit >=1.8.0.1
     , xml-conduit-writer >=0.1.1.2
     , xml-hamlet >=0.5.0.1
@@ -304,7 +304,8 @@ test-suite spec
     , case-insensitive >=1.2.1.0
     , containers >=0.6.0.1
     , cookie >=0.4.4
-    , cryptonite >=0.25
+    , crypton >=0.30
+    , crypton-x509 >=1.7.5
     , data-default >=0.7.1.1
     , directory >=1.3.6.0
     , dns >=4.0.0
@@ -327,6 +328,7 @@ test-suite spec
     , http-types >=0.12.3
     , hxt >=9.3.1.18
     , lens >=4.17.1
+    , lens-datetime >=0.3
     , memory >=0.14.18
     , mtl >=2.2.2
     , network-uri >=2.6.1.0
@@ -352,7 +354,6 @@ test-suite spec
     , wai-extra >=3.0.28
     , warp >=3.2.28
     , word8 >=0.1.3
-    , x509 >=1.7.5
     , xml-conduit >=1.8.0.1
     , xml-conduit-writer >=0.1.1.2
     , xml-hamlet >=0.5.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,10 +5,12 @@ packages:
 
 extra-deps:
 - git: https://github.com/wireapp/hsaml2
-  commit: b652ec6e69d1647e827cbee0fa290605ac09dc63  # https://github.com/wireapp/hsaml2/pull/9 (Feb 18, 2021)
+  commit: 51d1fcecebf2417e658b9a78943c84a76a0ed347
 - git: https://github.com/wireapp/hspec-wai
-  commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25  # https://github.com/hspec/hspec-wai/pull/49
+  commit: 08176f07fa893922e2e78dcaf996c33d79d23ce2 # https://github.com/hspec/hspec-wai/pull/49
 - invertible-hxt-0.1  # for hsaml2
+- crypton-x509-1.7.6
+- crypton-0.33
 
 - ormolu-0.1.4.1
 - ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751  # for ormolu

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,51 +5,65 @@
 
 packages:
 - completed:
+    commit: 51d1fcecebf2417e658b9a78943c84a76a0ed347
+    git: https://github.com/wireapp/hsaml2
     name: hsaml2
-    version: '0.1'
-    git: https://github.com/wireapp/hsaml2
     pantry-tree:
-      size: 3918
-      sha256: 072d64ee1d974ed2170e4b0dacfeef2cb13ae62fe066211e93c0be0073f959a3
-    commit: b652ec6e69d1647e827cbee0fa290605ac09dc63
+      sha256: be0555fd87157a535e8833e99472b8f64c16d568836cd00908292caf46cc2079
+      size: 4098
+    version: 0.1.2
   original:
+    commit: 51d1fcecebf2417e658b9a78943c84a76a0ed347
     git: https://github.com/wireapp/hsaml2
-    commit: b652ec6e69d1647e827cbee0fa290605ac09dc63
 - completed:
+    commit: 08176f07fa893922e2e78dcaf996c33d79d23ce2
+    git: https://github.com/wireapp/hspec-wai
     name: hspec-wai
-    version: 0.9.2
-    git: https://github.com/wireapp/hspec-wai
     pantry-tree:
-      size: 1829
-      sha256: 1da15bc431ded925782e30d299556f7c33ab89fa74e5a519061081616fb9f4d7
-    commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25
+      sha256: f5f266a2806abcfaa6823c9f81bbc7f777306dc9006a36d389560c79d6b4e32c
+      size: 1899
+    version: 0.11.1
   original:
+    commit: 08176f07fa893922e2e78dcaf996c33d79d23ce2
     git: https://github.com/wireapp/hspec-wai
-    commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25
 - completed:
     hackage: invertible-hxt-0.1@sha256:8495092e94f6a7eebbdf980a8ccd3684f2078b02b2faf4b4822b1202ee42dae9,865
     pantry-tree:
-      size: 195
       sha256: da65a22968a2fecc17f42e66f1f3d0d2f341e4af50bf496c6c0fe84c0907f756
+      size: 195
   original:
     hackage: invertible-hxt-0.1
 - completed:
-    hackage: ormolu-0.1.4.1@sha256:2381482127734d1897cdb8a191033ef40e4d1bdc3c9af31bd6ef2b8d5ce5429a,6292
+    hackage: crypton-x509-1.7.6@sha256:c567657a705b6d6521f9dd2de999bf530d618ec00f3b939df76a41fb0fe94281,2339
     pantry-tree:
+      sha256: 729e7db8dfc0a8b43e08bbd8d1387c9065e39beda6ac39e0fb9f10140810a3eb
+      size: 1080
+  original:
+    hackage: crypton-x509-1.7.6
+- completed:
+    hackage: crypton-0.33@sha256:5e92f29b9b7104d91fcdda1dec9400c9ad1f1791c231cc41ceebd783fb517dee,18202
+    pantry-tree:
+      sha256: 38809499d7f9775ef45cd29ab5c3dc9b283a813f34c1cdc56681b24f8cf8bb4f
+      size: 23148
+  original:
+    hackage: crypton-0.33
+- completed:
+    hackage: ormolu-0.1.4.1@sha256:ed404eac6e4eb64da1ca5fb749e0f99907431a9633e6ba34e44d260e7d7728ba,6499
+    pantry-tree:
+      sha256: 86dffe835089c8029e99046a75e7350fae8b80266a352a7295f13a279a8e5363
       size: 74141
-      sha256: 30493b995b2652a9de3e7f080bd3745b0682c2f578ec8ad441df8fa5615b393f
   original:
     hackage: ormolu-0.1.4.1
 - completed:
     hackage: ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751
     pantry-tree:
-      size: 19497
       sha256: b11275740480138dd1fce4a22a2aa8835cddfecaa8da58a153f130b4575f9df5
+      size: 19497
   original:
     hackage: ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751
 snapshots:
 - completed:
+    sha256: 63539429076b7ebbab6daa7656cfb079393bf644971156dc349d7c0453694ac2
     size: 586296
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
-    sha256: 63539429076b7ebbab6daa7656cfb079393bf644971156dc349d7c0453694ac2
   original: lts-18.18


### PR DESCRIPTION
Migrate from the now archived cryptonite to crypton as the underlying cryptographic library.
